### PR TITLE
Fix default subscription link for feedly

### DIFF
--- a/common.js
+++ b/common.js
@@ -11,7 +11,7 @@ var storageEnabled = window.localStorage != null;
 function defaultReaderList() {
   // This is the default list, unless replaced by what was saved previously.
   return [
-    { 'url': 'http://www.feedly.com/home#subscription/feed/%s[action.subscribe',
+    { 'url': 'http://www.feedly.com/home#subscription/feed/%s',
       'description': 'Feedly'
     },
     { 'url': 'http://www.newsblur.com/?url=%s',


### PR DESCRIPTION
It appears feedly no longer recognizes the "[action.subscribe" appendage on the subscription URL. Updated the default value in common.js to reflect this change.
