### PR TITLE
Removed now deprecated escape function and replaced with encodeURICompon...

### DIFF
--- a/popup.js
+++ b/popup.js
@@ -63,7 +63,7 @@ function preview(feed_url) {
   var url = "";
   if (window.localStorage && window.localStorage.showPreviewPage == "No") {
     // Skip the preview.
-    url = window.localStorage.defaultReader.replace("%s", escape(feed_url));
+    url = window.localStorage.defaultReader.replace("%s", encodeURIComponent(feed_url));
   } else {
     // Show the preview page.
     url = "subscribe.html?" + encodeURIComponent(feed_url);


### PR DESCRIPTION
...ent. This means that when skipping the preview page the rss address will still be URL encoded.

I'd like this change to be made so that I can use the extension with Digg Reader without having to view the preview page, by using "http://digg.com/reader/search/%s" in settings.
